### PR TITLE
Bump gradle from 7.2.2 to 7.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Bumps gradle from 7.2.2 to 7.4.0.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>